### PR TITLE
add the ability to filter files returned in list_files by metadata.

### DIFF
--- a/src/onecontext/context.py
+++ b/src/onecontext/context.py
@@ -147,6 +147,7 @@ class Context:
         skip=0,
         limit=500,
         sort="date_created",
+        metadata_filters: Optional[Dict[str, Any]] = None,
         get_download_urls: bool = False,
     ) -> List[File]:
         """
@@ -162,6 +163,8 @@ class Context:
             The number of files to skip (default is 0).
         limit : int, optional
             The maximum number of files to return (default is 20).
+        metadata_filters : dict[str, Any]
+            Filter the files you return with OneContext Structured Query Language.
         sort : str, optional
             The field to sort by (default is "date_created").
             Reverse with "-date_created"
@@ -187,6 +190,7 @@ class Context:
                 "limit": limit,
                 "sort": sort,
                 "getDownloadUrls": get_download_urls,
+                "metadataFilters": metadata_filters,
                 "fileIds": file_ids,
                 "fileNames": file_names,
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,27 +12,27 @@ from onecontext.main import OneContext
 load_dotenv()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def api_key():
     return os.getenv("ONECONTEXT_API_KEY")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def base_url():
-    return os.getenv("ONECONTEXT_BASE_URL", "https://app.onecontext.ai/api/v5/")
+    return os.getenv("ONECONTEXT_BASE_URL", "https://app.onecontext.ai/api/v6/")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def bypass():
     return os.getenv("BYPASS")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def anthropic_api_key():
     return os.getenv("ANTHROPIC_API_KEY")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def client(api_key, base_url, bypass, anthropic_api_key):
     extra_headers = {"x-vercel-protection-bypass": bypass}
 
@@ -42,12 +42,12 @@ def client(api_key, base_url, bypass, anthropic_api_key):
     return client
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def test_files_directory() -> str:
     return os.path.join(os.path.dirname(__file__), "files")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def file_paths(test_files_directory) -> List[str]:
     return [
         os.path.join(test_files_directory, f)

--- a/tests/test_search_context.py
+++ b/tests/test_search_context.py
@@ -9,7 +9,7 @@ from onecontext.context import Context, StructuredOutputModel
 from onecontext.main import OneContext
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def context(client: OneContext):
     context_name = f"test_context_{__name__}"
 

--- a/tests/test_search_context.py
+++ b/tests/test_search_context.py
@@ -31,6 +31,22 @@ def context_with_files(context: Context, file_paths: list):
     assert len(files) > 0
 
 
+def test_list_files(context_with_files: Context):
+    metadata_filters = {"file_tag": {"$eq": "file_1"}}
+    files = context_with_files.list_files(metadata_filters=metadata_filters)
+
+    for file in files:
+        assert file.metadata_json
+        assert file.metadata_json.get("file_tag") == "file_1"
+
+    metadata_filters = {"file_tag": {"$eq": "file_2"}}
+    files = context_with_files.list_files(metadata_filters=metadata_filters)
+
+    for file in files:
+        assert file.metadata_json
+        assert file.metadata_json.get("file_tag") == "file_2"
+
+
 def test_list_chunks(context_with_files: Context):
     files = context_with_files.list_files()
 

--- a/tests/test_search_context.py
+++ b/tests/test_search_context.py
@@ -21,7 +21,7 @@ def context(client: OneContext):
         client.delete_context(context_name)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def context_with_files(context: Context, file_paths: list):
     metadata = [{"file_tag": "file_1"}, {"file_tag": "file_2"}]
     context.upload_files(file_paths, metadata=metadata, max_chunk_size=200)

--- a/tests/test_upload_files.py
+++ b/tests/test_upload_files.py
@@ -30,8 +30,6 @@ def download_file(file_url, local_path):
 def test_upload_files(client: OneContext, context: Context, file_paths: list):
     metadata = [{"file_tag": "file_1"}, {"file_tag": "file_2"}]
 
-    # file_paths = [file_paths[0]]
-    # metadata = [metadata[0]]
     file_ids = context.upload_files(file_paths, metadata=metadata)
 
     wait_for_file_processing(context)


### PR DESCRIPTION
- please merge in turn with the backend PR
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `metadata_filters` to `list_files()` in `context.py` for metadata-based file filtering, with corresponding test updates.
> 
>   - **Behavior**:
>     - Add `metadata_filters` parameter to `list_files()` in `context.py` to filter files by metadata using OneContext Structured Query Language.
>     - Update request payload in `list_files()` to include `metadataFilters` key.
>   - **Tests**:
>     - Add `test_list_files()` in `test_search_context.py` to verify filtering by `metadata_filters`.
>     - Update `test_upload_files.py` to ensure metadata is correctly uploaded and verified.
>     - Modify fixtures in `conftest.py` to use `scope="session"` for efficiency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=onecontext%2Fonecontext-python&utm_source=github&utm_medium=referral)<sup> for a3f6e2c73097cd6d4882ed9c92a779f81081c2e2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->